### PR TITLE
Fix flake8 and tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
 FROM journald-2-cloudwatch
 
 RUN pip3 --no-cache-dir install pytest pytest-cov codecov requests_mock
-ENTRYPOINT ["pytest", "/jd2cw/tests", "-vv", "--cov=jd2cw", "--cov-report=term", "--cov-report=xml:/tmp/codecov/coverage.xml"]
+ENTRYPOINT ["pytest", "-ocache_dir=/dev/null", "/jd2cw/tests", "-vv", "--cov=jd2cw", "--cov-report=term", "--cov-report=xml:/tmp/codecov/coverage.xml"]

--- a/jd2cw/__init__.py
+++ b/jd2cw/__init__.py
@@ -21,6 +21,7 @@ def print_version(ctx, param, value):
     click.echo('Version {}'.format(version))
     ctx.exit()
 
+
 python_aws_mapping = {'destination_arn': 'destinationArn',
                       'filter_name': 'filterName',
                       'filter_pattern': 'filterPattern',

--- a/jd2cw/client.py
+++ b/jd2cw/client.py
@@ -20,7 +20,7 @@ class JournalMsgEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-seq_token_finder = re.compile('\d{16,}').search
+seq_token_finder = re.compile(r'\d{16,}').search
 
 
 class CloudWatchClient:


### PR DESCRIPTION
> W605 invalid escape sequence '\d'
> E305 expected 2 blank lines after class or function definition, found 1