### PR TITLE
Use Ubuntu Xenial for Docker base image and python3-systemd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,17 @@ VOLUME /etc/jd2cw/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-RUN apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y python3-systemd python3-pip python3-setuptools \
-  && rm -rf /var/lib/apt/lists/*
-
 RUN mkdir /jd2cw
 WORKDIR /jd2cw
 COPY jd2cw /jd2cw/jd2cw
 COPY setup.py /jd2cw/
-RUN python3 setup.py install
+
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install --no-install-recommends -y python3-minimal python3-systemd python3-pip python3-setuptools \
+  && pip3 install --no-cache-dir -e . \
+  && apt-get purge -y python3-pip \
+  && apt-get autoremove -y --purge \
+  && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["jd2cw"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM ubuntu:xenial
 
 VOLUME /etc/jd2cw/
 
@@ -6,21 +6,15 @@ VOLUME /etc/jd2cw/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-# Install Python, pip, boto3 and python-systemd.
-RUN BUILD_DEPS="curl python3-dev pkg-config gcc git libsystemd-dev" \
-    VERSION="234"; \
-    apt-get update && \
-    apt-get install --no-install-recommends --yes python3 \
-      python3-pip python3-setuptools $BUILD_DEPS && \
-    pip3 install --no-cache-dir "git+https://github.com/systemd/python-systemd.git/@v$VERSION#egg=systemd" && \
-    apt-get purge --auto-remove -y $BUILD_DEPS && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install --no-install-recommends -y python3-systemd python3-pip python3-setuptools \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /jd2cw
 WORKDIR /jd2cw
 COPY jd2cw /jd2cw/jd2cw
 COPY setup.py /jd2cw/
-RUN pip3 install -e "."
+RUN python3 setup.py install
 
 ENTRYPOINT ["jd2cw"]
 CMD ["--help"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,9 @@
 FROM journald-2-cloudwatch
 
-RUN pip3 --no-cache-dir install pytest pytest-cov codecov requests_mock
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y python3-pip \
+  && pip3 --no-cache-dir install pytest pytest-cov requests_mock \
+  && apt-get purge -y python3-pip \
+  && apt-get autoremove -y --purge \
+  && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["pytest", "-ocache_dir=/dev/null", "/jd2cw/tests", "-vv", "--cov=jd2cw", "--cov-report=term", "--cov-report=xml:/tmp/codecov/coverage.xml"]

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,6 @@ docker_test: docker_build_test
 	  -e AWS_DEFAULT_REGION=eu-west-1 \
 	  -e AWS_ACCESS_KEY_ID=abc \
 	  -e AWS_SECRET_ACCESS_KEY=abc \
-		-w $$CODECOV_TMP \
+	  -w $$CODECOV_TMP \
 	  journald-2-cloudwatch-test
+	docker run --rm journald-2-cloudwatch

--- a/jd2cw/version.py
+++ b/jd2cw/version.py
@@ -1,1 +1,1 @@
-version = '0.0.2.dev'
+version = '0.1.0'


### PR DESCRIPTION
This is meant to match our host system better, and hopefully helps with
lost messages.